### PR TITLE
Use default int when value is none

### DIFF
--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -528,7 +528,7 @@ actions:
               sequence:
                 - action: light.turn_on
                   data:
-                    color_temp: '{{ state_attr(light,"color_temp")|int + 50 }}'
+                    color_temp: '{{ state_attr(light,"color_temp")|int(0) + 50 }}'
                     transition: 0.25
                   entity_id: !input light
             - conditions: '{{ light_color_mode_id == "hs_color" }}'
@@ -545,7 +545,7 @@ actions:
               sequence:
                 - action: light.turn_on
                   data:
-                    color_temp: '{{ [state_attr(light,"color_temp")|int - 50, 1]|max }}'
+                    color_temp: '{{ [state_attr(light,"color_temp")|int(0) - 50, 1]|max }}'
                     transition: 0.25
                   entity_id: !input light
             - conditions: '{{ light_color_mode_id == "hs_color" }}'
@@ -565,7 +565,7 @@ actions:
                     sequence:
                       - action: light.turn_on
                         data:
-                          color_temp: '{{ state_attr(light,"color_temp")|int + 50 }}'
+                          color_temp: '{{ state_attr(light,"color_temp")|int(0) + 50 }}'
                           transition: 0.25
                         entity_id: !input light
                       - delay:
@@ -592,7 +592,7 @@ actions:
                     sequence:
                       - action: light.turn_on
                         data:
-                          color_temp: '{{ [state_attr(light,"color_temp")|int - 50, 1]|max }}'
+                          color_temp: '{{ [state_attr(light,"color_temp")|int(0) - 50, 1]|max }}'
                           transition: 0.25
                         entity_id: !input light
                       - delay:


### PR DESCRIPTION
Hi

I had following issue when I used the light hook and switching the color temperature:
Error rendering data template: ValueError: Template error: int got invalid input 'None' when rendering template

So changed the template to use a default int value when the input is None.

BR