### PR TITLE
Fix Z2M values for Philipps remote

### DIFF
--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -44,7 +44,6 @@ blueprint:
             - integration: mqtt
               manufacturer: Philips
               model: Hue dimmer switch
-              model_id: 324131092621
             # For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
             - integration: mqtt
               manufacturer: Philips
@@ -338,18 +337,18 @@ variables:
       button_down_release: [down_long_release]
     zigbee2mqtt:
       # source: https://www.zigbee2mqtt.io/devices/324131092621.html#philips-324131092621
-      button_on_short: [on-press]
-      button_on_long: [on-hold]
-      button_on_release: [on-hold-release]
-      button_off_short: [off-press]
-      button_off_long: [off-hold]
-      button_off_release: [off-hold-release]
-      button_up_short: [up-press]
-      button_up_long: [up-hold]
-      button_up_release: [up-hold-release]
-      button_down_short: [down-press]
-      button_down_long: [down-hold]
-      button_down_release: [down-hold-release]
+      button_on_short: [on_press]
+      button_on_long: [on_hold]
+      button_on_release: [on_hold_release]
+      button_off_short: [off_press]
+      button_off_long: [off_hold]
+      button_off_release: [off_hold_release]
+      button_up_short: [up_press]
+      button_up_long: [up_hold]
+      button_up_release: [up_hold_release]
+      button_down_short: [down_press]
+      button_down_long: [down_hold]
+      button_down_release: [down_hold_release]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_on_short: '{{ actions_mapping[integration_id]["button_on_short"] }}'


### PR DESCRIPTION
## Proposed change

Fixes Z2M values for one of the remotes. `model_id` is not supported by HA, throws an error. Also the button press values need underscores

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [x] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
