### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr_commenter_result.yml
+++ b/.github/workflows/pr_commenter_result.yml
@@ -1,5 +1,9 @@
 name: PR Commenter
 
+permissions:
+  contents: read
+  pull-requests: write
+
 'on':
   workflow_run:
     workflows:


### PR DESCRIPTION
Potential fix for [https://github.com/yarafie/awesome-ha-blueprints/security/code-scanning/30](https://github.com/yarafie/awesome-ha-blueprints/security/code-scanning/30)

To fix the issue, you should add a top-level `permissions` block to the workflow file (.github/workflows/pr_commenter_result.yml), restricting the GITHUB_TOKEN granted to jobs to only the minimum necessary permissions. Since the workflow reads repository artifacts and writes comments to pull requests, `contents: read` allows reading artifacts, and `pull-requests: write` is required for posting comments. The best location is immediately beneath the workflow `name` and before the `on:` block, or following the `on:` block at the root (but before `jobs`). No other functionality change is needed—just this addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
