### PR TITLE
Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/label_management.yml
+++ b/.github/workflows/label_management.yml
@@ -2,6 +2,10 @@
 # yamllint disable rule:line-length
 # Workflows which handle labels in repository issues and PRs
 name: Issues & PRs label management
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 'on':
   issues:


### PR DESCRIPTION
Potential fix for [https://github.com/yarafie/awesome-ha-blueprints/security/code-scanning/25](https://github.com/yarafie/awesome-ha-blueprints/security/code-scanning/25)

To resolve the issue and adhere to GitHub best practices, add an explicit `permissions` block to the workflow. Since this workflow only needs to remove labels on issues and pull requests, the required permissions are minimal: `contents: read`, `issues: write`, and `pull-requests: write`. The `permissions` block should be placed at the root of the workflow, directly after the `name:` and before the `on:` section, ensuring all jobs inherit these least privilege settings unless overridden. No existing functionality will be affected—only the security posture is improved.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
