### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr_commenter.yml
+++ b/.github/workflows/pr_commenter.yml
@@ -5,6 +5,9 @@ name: PR Commenter
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   thank-you-message:
     name: Thank you message


### PR DESCRIPTION
Potential fix for [https://github.com/yarafie/awesome-ha-blueprints/security/code-scanning/22](https://github.com/yarafie/awesome-ha-blueprints/security/code-scanning/22)

The best fix is to add an explicit `permissions` block with the minimum required scopes before the jobs section in `.github/workflows/pr_commenter.yml`. This ensures that all jobs (and specifically the `thank-you-message` job) receive only the GitHub token permissions needed for their steps. In this case, since we are posting a comment to a pull request, we need `pull-requests: write`. It is also conventional to add `contents: read`, unless proven unnecessary, since the default minimal permissions include `contents: read`. This change should be applied at the root level of the workflow YAML, above `jobs:`.  
No additional imports, libraries, or definitions are needed – just a YAML-edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
