### PR TITLE
CI: Enforce contributor branch naming & filesystem scope

### DIFF
--- a/.github/workflows/ahb-validate-branch.yml
+++ b/.github/workflows/ahb-validate-branch.yml
@@ -18,20 +18,21 @@ jobs:
           echo "Not an ahb/* branch – skipping validation."
           exit 0
 
-    steps:
       - name: Checkout repository (full history)
+        if: ${{ startsWith(github.head_ref, 'ahb/') }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Compute changed files vs main
+        if: ${{ startsWith(github.head_ref, 'ahb/') }}
         run: |
           git fetch origin main
           git diff --name-only origin/main...HEAD > changed_files.txt
-          echo "Changed files:"
           cat changed_files.txt
 
       - name: Validate branch name and filesystem scope
+        if: ${{ startsWith(github.head_ref, 'ahb/') }}
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: |


### PR DESCRIPTION
## Purpose

This PR introduces a mandatory CI guard that enforces:

- Canonical contributor branch naming:
  ahb/<category>/.../vYYYY.MM.DD/author-<github_username>
- Filesystem scope isolation per submission
- Alignment with locked Controllers / Hooks / Automations tree schemas

## Why this matters

This is a foundational safety rail for:
- future contributor uploads
- automated PR creation
- eventual auto-merge pipelines

No contributor code can land outside its declared scope.

## Notes

- No auto-merge enabled
- No behavior changes to existing library content
- Fails closed by design