### PR TITLE
ikea_e2201.yaml: change "stop" to "stop_with_on_off"

### DIFF
--- a/website/docs/blueprints/controllers/ikea_e2201/EPMatt/2025.10.01/ikea_e2201.yaml
+++ b/website/docs/blueprints/controllers/ikea_e2201/EPMatt/2025.10.01/ikea_e2201.yaml
@@ -320,7 +320,7 @@ triggers:
     event_type: zha_event
     event_data:
       device_id: !input controller_device
-      command: stop
+      command: stop_with_on_off
       endpoint_id: 1
       cluster_id: 8
   # triggers for deCONZ
@@ -650,7 +650,7 @@ actions:
                                       event_type: zha_event
                                       event_data:
                                         device_id: !input controller_device
-                                        command: stop
+                                        command: stop_with_on_off
                                         cluster_id: 8
                                         endpoint_id: 1
                                     - trigger: event


### PR DESCRIPTION
The RODRET controller down button long press action currently waits for a `stop` command to be fired in a `zha_event`, but the actual command is `stop_with_on_off` (the same as when letting go of an up button long press).

E.g., when letting go of a long press:
```yaml
event_type: zha_event
data:
  device_ieee: ...
  unique_id: ...
  device_id: ...
  endpoint_id: 1
  cluster_id: 8
  command: stop_with_on_off
  args: []
  params: {}
origin: LOCAL
time_fired: "2026-01-13T00:33:23.818663+00:00"
context:
  id: ...
  parent_id: null
  user_id: null
```

That means that currently the controller will not detect a release and will just dim the lights all the way (or repeat whatever other action is configured, up to the repeat limit). This PR changes the command to `stop_with_on_off`.

## Breaking change

Does not break anything, unless other RODRET controllers produce `stop` instead of `stop_with_on_off` events. I don't have any other controllers to test this with.

## Proposed change

Change `event_data/command` key to `stop_with_on_off` (see diff) in both the top level trigger and in the "loop break"  trigger.

## Checklist

- [x] I followed sections of the [Contribution Guidelines](https://github.com/yarafie/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [ ] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.

## Other Notes

It seems like the top-level button-up-release/button-down-release actions (very end of the file, after the "looping" button-up-long/button-down-long) never trigger. I'm not sure why, maybe it's because the loop from button-up-long/button-down-long "capture" those triggers?

In any case, the triggers for the up-release and the down-release are exactly the same, at least in ZHA (as of this PR) and z2m. Only in DeCONZ are the two triggers distinct. That means that these actions would never work properly if they actually triggered.