### PR TITLE
fix: IKEA E1743 TRÅDFRI doesn't stop after bottom long press

### DIFF
--- a/website/docs/blueprints/controllers/ikea_e1743/EPMatt/awesome/2025.10.12/ikea_e1743.yaml
+++ b/website/docs/blueprints/controllers/ikea_e1743/EPMatt/awesome/2025.10.12/ikea_e1743.yaml
@@ -653,7 +653,7 @@ actions:
                                       event_type: zha_event
                                       event_data:
                                         device_id: !input controller_device
-                                        command: stop
+                                        command: stop_with_on_off
                                         cluster_id: 8
                                         endpoint_id: 1
                                     - trigger: event


### PR DESCRIPTION
Hey! Thanks so much for maintaining the blueprints!

## Proposed / Breaking (?) change
I've set up my 2 button IKEA E1743 Tradfri remote with ZHA, more specifically up and bottom long presses, which change the brightness of my light. While up long press worked correctly, I noticed that the bottom long press didn't stop after release and eventually turned off my light. When I changed `stop` to `stop_with_on_off` (so the same as long press) the release was picked up correctly and dimming stopped.

To be clear - I haven't tested it for anything else.


## Checklist

- [x] I followed sections of the [Contribution Guidelines](https://github.com/yarafie/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [x] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
