### PR TITLE
fix: correct ikea_e2001_e2002 yarafie release integrations and hooks

### DIFF
--- a/website/docs/blueprints/controllers/ikea_e2001_e2002/manifest.yaml
+++ b/website/docs/blueprints/controllers/ikea_e2001_e2002/manifest.yaml
@@ -14,14 +14,7 @@ maintainers:
   - id: 'EPMatt'
     name: 'EPMatt'
 supported_integrations:
-  - 'ZHA'
   - 'Zigbee2MQTT'
-  - 'deCONZ'
-  - 'input_text'
-supported_hooks:
-  - 'cover'
-  - 'light'
-  - 'media_player'
 tags:
   - 'zigbee'
   - 'button'
@@ -38,3 +31,17 @@ external_references:
     url: 'https://github.com/dresden-elektronik/deconz-rest-plugin/blob/master/devices/ikea/styrbar_remote_control.json'
 has_long_press_loop: true
 has_virtual_double_press: true
+releases:
+  awesome:
+    supported_integrations:
+      - 'Zigbee2MQTT'
+      - 'ZHA'
+      - 'deCONZ'
+      - 'input_text'
+    supported_hooks:
+      - 'light'
+      - 'cover'
+      - 'media_player'
+  anything:
+    supported_hooks:
+      - 'none'

--- a/website/scripts/generate.mjs
+++ b/website/scripts/generate.mjs
@@ -339,10 +339,18 @@ function generateLibraryJson(
     status: manifest.status || 'active',
   }
 
-  if (manifest.supported_integrations) {
-    result.supported_integrations = getActualIntegrations(
-      manifest.supported_integrations,
-    )
+  // Aggregate integrations from all releases in this library
+  const allIntegrations = new Set()
+  for (const rid of releaseIds) {
+    const rc = getReleaseConfig(manifest, rid)
+    if (rc.supported_integrations) {
+      for (const i of getActualIntegrations(rc.supported_integrations)) {
+        allIntegrations.add(i)
+      }
+    }
+  }
+  if (allIntegrations.size > 0) {
+    result.supported_integrations = [...allIntegrations]
   }
 
   return result


### PR DESCRIPTION
## Summary

Follow-up to #514.

- The yarafie/anything release for ikea_e2001_e2002 was incorrectly showing all 3 integrations (Zigbee2MQTT, ZHA, deCONZ) and hooks (light, cover, media_player), when it only supports Zigbee2MQTT with no hooks
- Added per-release overrides to `manifest.yaml` using the same pattern as multi-release blueprints
- Fixed `generateLibraryJson` to aggregate integrations from release configs instead of reading top-level manifest defaults

## Test plan

- [x] `pnpm run lint` passes
- [x] `pnpm run format` passes
- [x] `pnpm run docs:build` passes
- [x] Verified yarafie library.json shows only `Zigbee2MQTT`
- [x] Verified EPMatt library.json shows `Zigbee2MQTT, ZHA, deCONZ`
- [x] Verified yarafie release.json shows `supported_hooks: none`
- [x] Verified EPMatt release.json shows `supported_hooks: light, cover, media_player`
- [x] Spot-checked other blueprints — no regressions
- [x] Checked locally with `docs:start`